### PR TITLE
remove dtype hash hack since it is fixed in pypy

### DIFF
--- a/dtypes.py
+++ b/dtypes.py
@@ -31,41 +31,7 @@ import numpy as np
 
 # {{{ registry
 
-try:
-    hash(np.dtype([('s1', np.int8), ('s2', np.int8)]))
-    DTypeDict = dict
-    dtype_to_key = lambda t: t
-    dtype_hashable = True
-except:
-    import json as _json
-    dtype_hashable = False
-    dtype_to_key = lambda t: _json.dumps(t.descr, separators=(',', ':'))
-    class DTypeDict:
-        def __init__(self):
-            self.__dict = {}
-            self.__type_dict = {}
-        def __delitem__(self, key):
-            try:
-                del self.__dict[key]
-            except TypeError:
-                del self.__type_dict[dtype_to_key(key)]
-        def __setitem__(self, key, val):
-            try:
-                self.__dict[key] = val
-            except TypeError:
-                self.__type_dict[dtype_to_key(key)] = val
-        def __getitem__(self, key):
-            try:
-                return self.__dict[key]
-            except TypeError:
-                return self.__type_dict[dtype_to_key(key)]
-        def __contains__(self, key):
-            try:
-                return key in self.__dict
-            except TypeError:
-                return dtype_to_key(key) in self.__type_dict
-
-DTYPE_TO_NAME = DTypeDict()
+DTYPE_TO_NAME = {}
 NAME_TO_DTYPE = {}
 
 


### PR DESCRIPTION
See also pyopencl/pyopencl#64
