### PR TITLE
Ignore __restrict__ when parsing c args

### DIFF
--- a/dtypes.py
+++ b/dtypes.py
@@ -210,7 +210,7 @@ def parse_c_arg_backend(c_arg, scalar_arg_factory, vec_arg_factory,
     elif name_to_dtype is None:
         name_to_dtype = NAME_TO_DTYPE.__getitem__
 
-    c_arg = c_arg.replace("const", "").replace("volatile", "")
+    c_arg = c_arg.replace("const", "").replace("volatile", "").replace("__restrict__", "")
 
     # process and remove declarator
     import re


### PR DESCRIPTION
This allows using __restrict__ in arguments to pycuda ElementwiseKernel. Sometimes allows the compiler better to optimize the code. 