### PR TITLE
Fill registry with C vector extension types

### DIFF
--- a/dtypes.py
+++ b/dtypes.py
@@ -203,39 +203,19 @@ def fill_registry_with_c99_complex_types(reg):
     reg.get_or_register_dtype("double complex", np.complex128)
     reg.get_or_register_dtype("long double complex", np.clongdouble)
 
+
 def _create_vector_types():
     names_and_dtypes = []
 
-    counts = [2, 3, 4, 8, 16]
+    for base_type in [np.int8, np.uint8, np.int16, np.uint16,
+                      np.int32, np.uint32, np.int64, np.uint64,
+                      np.float32, np.float64]:
 
-    for base_name, base_type in [
-            ('char', np.int8),
-            ('unsigned char', np.uint8),
-            ('short', np.int16),
-            ('unsigned short', np.uint16),
-            ('int', np.int32),
-            ('unsigned int', np.uint32),
-            ('long', np.int64),
-            ('unsigned long', np.uint64),
-            ('float', np.float32),
-            ('double', np.float64),
-            ]:
-        for count in counts:
+        for count in [2, 3, 4, 8, 16]:
+
             base_dtype = np.dtype(base_type)
-            size = base_dtype.itemsize
-            byte_count = count*size
-            new_name = "v%d%s%d" % (count, base_dtype.kind, base_dtype.itemsize)
-            name = "%s __attribute__((vector_size(%d)))" % (new_name,
-                    byte_count)
-
-            names = ["%s" % (new_name) ]
-            titles = ["%s" %  (np.dtype(base_dtype).str)]
-
-            dtype = np.dtype(dict(
-                    names=names,
-                    formats=[base_type],
-                    titles=titles))
-
+            name = "v%d%s%d" % (count, base_dtype.kind, base_dtype.itemsize)
+            dtype = np.dtype((base_dtype, count))
             names_and_dtypes.append((dtype, name))
     return names_and_dtypes
 

--- a/dtypes.py
+++ b/dtypes.py
@@ -203,6 +203,47 @@ def fill_registry_with_c99_complex_types(reg):
     reg.get_or_register_dtype("double complex", np.complex128)
     reg.get_or_register_dtype("long double complex", np.clongdouble)
 
+def _create_vector_types():
+    names_and_dtypes = []
+
+    counts = [2, 3, 4, 8, 16]
+
+    for base_name, base_type in [
+            ('char', np.int8),
+            ('unsigned char', np.uint8),
+            ('short', np.int16),
+            ('unsigned short', np.uint16),
+            ('int', np.int32),
+            ('unsigned int', np.uint32),
+            ('long', np.int64),
+            ('unsigned long', np.uint64),
+            ('float', np.float32),
+            ('double', np.float64),
+            ]:
+        for count in counts:
+            base_dtype = np.dtype(base_type)
+            size = base_dtype.itemsize
+            byte_count = count*size
+            new_name = "v%d%s%d" % (count, base_dtype.kind, base_dtype.itemsize)
+            name = "%s __attribute__((vector_size(%d)))" % (new_name,
+                    byte_count)
+
+            names = ["%s" % (new_name) ]
+            titles = ["%s" %  (np.dtype(base_dtype).str)]
+
+            dtype = np.dtype(dict(
+                    names=names,
+                    formats=[base_type],
+                    titles=titles))
+
+            names_and_dtypes.append((dtype, name))
+    return names_and_dtypes
+
+
+def fill_registry_with_cvec_types(reg):
+    for dtype, name in _create_vector_types():
+        reg.get_or_register_dtype(name, dtype)
+
 # }}}
 
 


### PR DESCRIPTION
Hi all, I would like to hear your opinion on extending compyte by adding C vector extension types.

In the code of this PR I am creating possible combinations of base types and batched numbers of the base types. I generate an alias for each of that vector extension types e.g. "v4f8" for a vector of 4 double values. Then I register it to the standard `DTypeRegistry`.

Whoever is using these vector types needs to typedef them in their preamble. In loopy this would happen along the lines of
```
def cvec_preamble_generator(preamble_info):
     preamble = ""
     type_register = preamble_info.kernel.target.get_dtype_registry()
     has_shape = lambda dtype: True if dtype.dtype.shape != () else False
     for dtype in filter(has_shape, preamble_info.seen_dtypes):
             base_name = type_register.wrapped_registry.dtype_to_name[dtype.dtype.base]
             new_name = type_register.wrapped_registry.dtype_to_name[dtype.dtype]
             preamble += ("typedef %s %s __attribute__((vector_size(%d)));\n" % 
                         (base_name, new_name, dtype.itemsize))
```

Adding this to compyte prevents the need of a specialised `DTypeRegistryWrapper` for the vector extensions and simplifies the preamble generation for the vector extensions in loopy.

I am wondering, if this is the right thing to do, since this is not quite matching to the documentation of the `DTypeRegistry` as @kaushikcfd pointed out. We are not registering the name of an in-built C type, but an alias for a vector version of an in-built C type.

Let me know what you think.