### PR TITLE
Fix strides for 0-sized empty arrays

### DIFF
--- a/array.py
+++ b/array.py
@@ -27,7 +27,10 @@ def f_contiguous_strides(itemsize, shape):
     if shape:
         strides = [itemsize]
         for s in shape[:-1]:
-            strides.append(strides[-1]*s)
+            # NOTE: max(1, s) is used to handle 0-sized axes in `shape`;
+            # the stride for `shape[i] <= 1` doesn't matter, but letting it be 0
+            # is not a good idea: https://github.com/inducer/arraycontext/pull/91
+            strides.append(strides[-1]*max(1, s))
         return tuple(strides)
     else:
         return ()
@@ -37,7 +40,10 @@ def c_contiguous_strides(itemsize, shape):
     if shape:
         strides = [itemsize]
         for s in shape[:0:-1]:
-            strides.append(strides[-1]*s)
+            # NOTE: max(1, s) is used to handle 0-sized axes in `shape`;
+            # the stride for `shape[i] <= 1` doesn't matter, but letting it be 0
+            # is not a good idea: https://github.com/inducer/arraycontext/pull/91
+            strides.append(strides[-1]*max(1, s))
         return tuple(strides[::-1])
     else:
         return ()


### PR DESCRIPTION
For 0-sized arrays, this returned
```
>> c_contiguous_strides(8, (18, 0))
(0, 8)
```
which messes up `cl.array.empty(queue, (18, 0), np.float64).strides`. On the other hand, `numpy` gives
```
>>> np.empty((18, 0)).strides
(8, 8)
```

Not sure this is the right general fix, but it does the trick for this little example.

xref: inducer/arraycontext#91.